### PR TITLE
0.1.1 recipe w/ hard version dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - python
     - setuptools
-    - gdal >= 2.1.4
+    - gdal >=2.1.4
   run:
     - python
     - matplotlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "geoplot" %}
-{% set version = "0.0.4" %}
-{% set md5 = "54ea09761a585756084d947d7e7b53d9" %}
+{% set version = "0.1.1" %}
+{% set md5 = "6cfdef89c92e196a86a764d365e3ddea" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/geoplot/geoplot-{{ version }}.tar.gz
-  md5: 54ea09761a585756084d947d7e7b53d9
+  md5: 6cfdef89c92e196a86a764d365e3ddea
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
@@ -24,7 +24,7 @@ requirements:
   build:
     - python
     - setuptools
-
+    - gdal >= 2.1.4
   run:
     - python
     - matplotlib


### PR DESCRIPTION
Cf. [here](https://github.com/conda-forge/kealib-feedstock/issues/15) for why this is necessary. This is a "dumb" but possibly good-enough way of fixing this issue